### PR TITLE
updates for version 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.bk
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rust:
 - nightly
 - beta
 - stable
+# Oldest supported version as dependency
+- 1.10.0
 matrix:
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 sudo: false
 language: rust
 rust:
-- nightly
 - beta
 - stable
 # Oldest supported version as dependency
 - 1.13.0
-matrix:
-  allow_failures:
-  - rust: nightly
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 - beta
 - stable
 # Oldest supported version as dependency
-- 1.10.0
+- 1.13.0
 matrix:
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
     - libcurl4-openssl-dev
     - libelf-dev
     - libdw-dev
-after_success:
-- travis-cargo --only stable doc-upload
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Jonathan Creekmore <jonathan@thecreekmores.org>"]
 description = "Parse and encode PEM-encoded data."
-documentation = "http://jcreekmore.github.io/pem-rs/"
+documentation = "https://docs.rs/pem/"
 homepage = "https://github.com/jcreekmore/pem-rs.git"
 license = "MIT"
 name = "pem"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 repository = "https://github.com/jcreekmore/pem-rs.git"
 version = "0.3.0"
 
+[badges]
+travis-ci = { repository = "jcreekmore/pem-rs" }
+
 [dependencies]
 error-chain = "0.10.0"
 lazy_static = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ version = "0.2.0"
 
 [dependencies]
 error-chain = "0.10.0"
+lazy_static = "0.2.6"
 regex = "0.1"
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "pem"
-version = "0.2.0"
 authors = ["Jonathan Creekmore <jonathan@thecreekmores.org>"]
-repository = "https://github.com/jcreekmore/pem-rs.git"
+description = "Parse and encode PEM-encoded data."
+documentation = "http://jcreekmore.github.io/pem-rs/"
 homepage = "https://github.com/jcreekmore/pem-rs.git"
 license = "MIT"
+name = "pem"
 readme = "README.md"
-documentation = "http://jcreekmore.github.io/pem-rs/"
-description = "Parse and encode PEM-encoded data."
+repository = "https://github.com/jcreekmore/pem-rs.git"
+version = "0.2.0"
 
 [dependencies]
-rustc-serialize = "0.3"
 regex = "0.1"
+rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ repository = "https://github.com/jcreekmore/pem-rs.git"
 version = "0.2.0"
 
 [dependencies]
+error-chain = "0.10.0"
 regex = "0.1"
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ version = "0.2.0"
 [dependencies]
 error-chain = "0.10.0"
 lazy_static = "0.2.6"
-regex = "0.1"
+regex = "0.2"
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "pem"
 readme = "README.md"
 repository = "https://github.com/jcreekmore/pem-rs.git"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 error-chain = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pem = "0.2"
+pem = "0.3"
 ```
 
 and this to your crate root:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,23 @@
+// Copyright 2017 Jonathan Creekmore
+//
+// Licensed under the MIT license <LICENSE.md or
+// http://opensource.org/licenses/MIT>. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![allow(missing_docs)]
+error_chain! {
+    foreign_links {
+        InvalidData(::rustc_serialize::base64::FromBase64Error);
+    }
+    errors {
+        MalformedFraming
+        MissingTag(t: String) {
+            description("missing tag")
+            display("missing \"{}\" tag", t)
+        }
+        MismatchedTags(b: String, e: String) {
+            description("mismatching BEGIN and END tags")
+            display("mismatching BEGIN (\"{}\") and END (\"{}\") tags", b, e)
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,13 +8,13 @@
 error_chain! {
     foreign_links {
         InvalidData(::rustc_serialize::base64::FromBase64Error);
+        NotUtf8(::std::str::Utf8Error);
     }
     errors {
         MalformedFraming
-        MissingTag(t: String) {
-            description("missing tag")
-            display("missing \"{}\" tag", t)
-        }
+        MissingBeginTag
+        MissingEndTag
+        MissingData
         MismatchedTags(b: String, e: String) {
             description("mismatching BEGIN and END tags")
             display("mismatching BEGIN (\"{}\") and END (\"{}\") tags", b, e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pem = "0.1"
+//! pem = "0.3"
 //! ```
 //!
 //! and this to your crate root:
@@ -164,14 +164,124 @@ impl Pem {
     }
 }
 
-/// Parses a single Pem-encoded data from a string.
+/// Parses a single PEM-encoded data from a data-type that can be dereferenced as a [u8].
+///
+/// # Example: parse PEM-encoded data from a Vec<u8>
+/// ```rust
+///
+/// use pem::parse;
+///
+/// const SAMPLE: &'static str = "-----BEGIN RSA PRIVATE KEY-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END RSA PRIVATE KEY-----
+/// ";
+/// let SAMPLE_BYTES: Vec<u8> = SAMPLE.into();
+///
+///  let pem = parse(SAMPLE_BYTES).unwrap();
+///  assert_eq!(pem.tag, "RSA PRIVATE KEY");
+/// ```
+///
+/// # Example: parse PEM-encoded data from a String
+/// ```rust
+///
+/// use pem::parse;
+///
+/// const SAMPLE: &'static str = "-----BEGIN RSA PRIVATE KEY-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END RSA PRIVATE KEY-----
+/// ";
+/// let SAMPLE_STRING: String = SAMPLE.into();
+///
+///  let pem = parse(SAMPLE_STRING).unwrap();
+///  assert_eq!(pem.tag, "RSA PRIVATE KEY");
+/// ```
 pub fn parse<B: AsRef<[u8]>>(input: B) -> Result<Pem> {
     ASCII_ARMOR.captures(&input.as_ref())
         .ok_or_else(|| ErrorKind::MalformedFraming.into())
         .and_then(Pem::new_from_captures)
 }
 
-/// Parses a set of Pem-encoded data from a string.
+/// Parses a set of PEM-encoded data from a data-type that can be dereferenced as a [u8].
+///
+/// # Example: parse a set of PEM-encoded data from a Vec<u8>
+///
+/// ```rust
+///
+/// use pem::parse_many;
+///
+/// const SAMPLE: &'static str = "-----BEGIN INTERMEDIATE CERT-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END INTERMEDIATE CERT-----
+///
+/// -----BEGIN CERTIFICATE-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END CERTIFICATE-----
+/// ";
+/// let SAMPLE_BYTES: Vec<u8> = SAMPLE.into();
+///
+///  let pems = parse_many(SAMPLE_BYTES);
+///  assert_eq!(pems.len(), 2);
+///  assert_eq!(pems[0].tag, "INTERMEDIATE CERT");
+///  assert_eq!(pems[1].tag, "CERTIFICATE");
+/// ```
+///
+/// # Example: parse a set of PEM-encoded data from a String
+///
+/// ```rust
+///
+/// use pem::parse_many;
+///
+/// const SAMPLE: &'static str = "-----BEGIN INTERMEDIATE CERT-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END INTERMEDIATE CERT-----
+///
+/// -----BEGIN CERTIFICATE-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END CERTIFICATE-----
+/// ";
+///  let SAMPLE_STRING: Vec<u8> = SAMPLE.into();
+///
+///  let pems = parse_many(SAMPLE_STRING);
+///  assert_eq!(pems.len(), 2);
+///  assert_eq!(pems[0].tag, "INTERMEDIATE CERT");
+///  assert_eq!(pems[1].tag, "CERTIFICATE");
+/// ```
 pub fn parse_many<B: AsRef<[u8]>>(input: B) -> Vec<Pem> {
     // Each time our regex matches a PEM section, we need to decode it.
     ASCII_ARMOR.captures_iter(&input.as_ref())
@@ -179,7 +289,18 @@ pub fn parse_many<B: AsRef<[u8]>>(input: B) -> Vec<Pem> {
         .collect()
 }
 
-/// Encode a Pem struct into a Pem-encoded data string
+/// Encode a PEM struct into a PEM-encoded data string
+///
+/// # Example
+/// ```rust
+///  use pem::{Pem, encode};
+///
+///  let pem = Pem {
+///     tag: String::from("FOO"),
+///     contents: vec![1, 2, 3, 4],
+///   };
+///   encode(&pem);
+/// ```
 pub fn encode(pem: &Pem) -> String {
     let mut output = String::new();
 
@@ -198,7 +319,24 @@ pub fn encode(pem: &Pem) -> String {
     output
 }
 
-/// Encode multiple Pem structs into a set of Pem-encoded data strings
+/// Encode multiple PEM structs into a PEM-encoded data string
+///
+/// # Example
+/// ```rust
+///  use pem::{Pem, encode_many};
+///
+///  let data = vec![
+///     Pem {
+///         tag: String::from("FOO"),
+///         contents: vec![1, 2, 3, 4],
+///     },
+///     Pem {
+///         tag: String::from("BAR"),
+///         contents: vec![5, 6, 7, 8],
+///     },
+///   ];
+///   encode_many(&data);
+/// ```
 pub fn encode_many(pems: &[Pem]) -> String {
     pems.iter().map(encode).collect::<Vec<String>>().join("\r\n")
 }


### PR DESCRIPTION
* use error-chain for error definition and handling
* use lazy_static to keep from building the Regex every time
* allow Pem structs to be parsed from anything that can convert to a [u8]
* update the documentation