### PR TITLE
Disable default features of regex crate to reduce dependencies, compile time, code size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 base64 = "^0.12"
 once_cell = "1.4"
-regex = "1"
+regex = {version = "1", default-features = false, features = ["std"]}
 
 [dev-dependencies]
 criterion = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ use regex::bytes::{Captures, Regex};
 use std::str;
 
 const REGEX_STR: &str =
-    r"(?s)-----BEGIN (?P<begin>.*?)-----\s*(?P<data>.*?)-----END (?P<end>.*?)-----\s*";
+    r"(?s)-----BEGIN (?P<begin>.*?)-----[ \t\n\r]*(?P<data>.*?)-----END (?P<end>.*?)-----[ \t\n\r]*";
 
 /// The line length for PEM encoding
 const LINE_WRAP: usize = 64;


### PR DESCRIPTION
This decreases number of dependencies from 8 to 4.

Disabled features are:
* `perf`
  * PEM decoding should not be in a critical path
* `unicode`
  * Unicode support is not needed for ASCII only files

It might be more ideal to build a special purpose simple parser for PEM files, but this was an easy change with relatively large benefits IMHO.