### PR TITLE
Chore: bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1.4"
 regex = {version = "1", default-features = false, features = ["std"]}
 
 [dev-dependencies]
-criterion = "0.2.3"
+criterion = "0.3.0"
 
 [[bench]]
 name = "pem_benchmark"


### PR DESCRIPTION
`criterion` to `0.3.0`

(this related for packaging for official Linux distros repos)