### PR TITLE
Make `parse_many` return a `Result<Vec<Pem>>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0 - master
+
+> Note: This version is not yet released and is under active development.
+
+ - `pem::parse_many` now returns a `Result<Vec<Pem>>` instead of a `Vec<Pem>` that silently discarded invalid sections.

--- a/benches/pem_benchmark.rs
+++ b/benches/pem_benchmark.rs
@@ -30,7 +30,7 @@ fn pem_parse() {
 }
 
 fn pem_parse_many() {
-    pem::parse_many(SAMPLE);
+    pem::parse_many(SAMPLE).unwrap();
 }
 
 fn pem_encode(pem: &pem::Pem) {


### PR DESCRIPTION
Thanks for the prompt reply in #27! :cake:

This PR changes `parse_many` to return a `Result`. Feel free to discard the `CHANGELOG.md` if you do not want to maintain it, I figured it'd be somewhat useful with the breaking change. 😃 