### PR TITLE
Add no_std crate attribute, fix resultant issues

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,8 +4,12 @@
 // http://opensource.org/licenses/MIT>. This file may not be
 // copied, modified, or distributed except according to those terms.
 use core::fmt;
+
 #[cfg(any(feature = "std", test))]
 use std::error::Error;
+
+#[cfg(not(any(feature = "std", test)))]
+use alloc::string::String;
 
 /// The `pem` error type.
 #[derive(Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,12 +117,16 @@
     unused_qualifications
 )]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #[cfg(not(any(feature = "std", test)))]
 extern crate alloc;
 #[cfg(not(any(feature = "std", test)))]
-use alloc::string::String;
-#[cfg(not(any(feature = "std", test)))]
-use alloc::vec::Vec;
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 mod errors;
 mod parser;


### PR DESCRIPTION
Sorry about the churn, just realized I'd forgotten the most important part!

Also, `cargo fmt --check` currently fails (due to both our changes). Guessing you'll take a pass on that before merging to master? Or does the `cargo fmt --all` step in the ci file actually modify the code before it is merged into the repository?