### PR TITLE
remove unused `serde-derive` feature of serde dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,8 @@ features = ["alloc"]
 
 [dependencies.serde]
 version = "1"
-optional = true
 default-features = false
-features = ["serde_derive"]
+optional = true
 
 [dev-dependencies]
 criterion = "0.3.0"


### PR DESCRIPTION
~~Based on the existing code, the `serde` feature only supports the std env and is optional, but when the `std` feature is enabled it will definitely cause the `serde` dependency to be introduced, which I don't think is the desired behavior.~~ 
see https://github.com/rust-lang/cargo/issues/10801 for details.

Also I remove the `serde_derive` feature of `serde` dependency, because we don't use it in the crate.