### PR TITLE
Add line_wrap to encoding config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
  - trim `proptest` features to prevent an MSRV break for testing
+ - make EncodeConfig struct extendable and add a line_wrap config option
 
 # 2.0.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ pub fn encode(pem: &Pem) -> String {
 ///  use pem::{Pem, encode_config, EncodeConfig, LineEnding};
 ///
 ///  let pem = Pem::new("FOO", [1, 2, 3, 4]);
-///  encode_config(&pem, EncodeConfig { line_ending: LineEnding::LF });
+///  encode_config(&pem, EncodeConfig::new().set_line_ending(LineEnding::LF));
 /// ```
 pub fn encode_config(pem: &Pem, config: EncodeConfig) -> String {
     let line_ending = match config.line_ending {
@@ -566,7 +566,7 @@ pub fn encode_many(pems: &[Pem]) -> String {
 ///     Pem::new("FOO", [1, 2, 3, 4]),
 ///     Pem::new("BAR", [5, 6, 7, 8]),
 ///   ];
-///   encode_many_config(&data, EncodeConfig { line_ending: LineEnding::LF });
+///   encode_many_config(&data, EncodeConfig::new().set_line_ending(LineEnding::LF));
 /// ```
 pub fn encode_many_config(pems: &[Pem], config: EncodeConfig) -> String {
     let line_ending = match config.line_ending {


### PR DESCRIPTION
This PR adds a `line_wrap` field to the `EncodeConfig` struct that determines the line length for the encoding.

Unfortunately this is a breaking change. To avoid it being a breaking change in the future, I made the fields private and added chain-able setter methods. Adding fields going forward would not be a breaking change, just a new feature.

After writing this, I came up with another idea that would avoid a breaking change. I could create a `struct Encoder` that essentially has the same state as `EncodeConfig` but private. `Encoder::encode(&self, &pem)` could handle encoding a PEM with the specified config without requiring any changes to the existing `encode` function or `EncodeConfig` struct.

I can put up a separate MR with that change if that is better, or if you'd like to compare.

Resolves #48