### PR TITLE
Reduce allocations in `pem::encode`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ use parser::{parse_captures, parse_captures_iter, Captures};
 
 pub use crate::errors::{PemError, Result};
 use base64::Engine as _;
+use core::fmt::Write;
 use core::{fmt, slice, str};
 
 /// The line length for PEM encoding
@@ -519,17 +520,17 @@ pub fn encode_config(pem: &Pem, config: EncodeConfig) -> String {
         base64::engine::general_purpose::STANDARD.encode(&pem.contents)
     };
 
-    output.push_str(&format!("-----BEGIN {}-----{}", pem.tag, line_ending));
+    write!(output, "-----BEGIN {}-----{}", pem.tag, line_ending).unwrap();
     if !pem.headers.0.is_empty() {
         for line in &pem.headers.0 {
-            output.push_str(&format!("{}{}", line.trim(), line_ending));
+            write!(output, "{}{}", line.trim(), line_ending).unwrap();
         }
         output.push_str(line_ending);
     }
     for c in contents.as_bytes().chunks(config.line_wrap) {
-        output.push_str(&format!("{}{}", str::from_utf8(c).unwrap(), line_ending));
+        write!(output, "{}{}", str::from_utf8(c).unwrap(), line_ending).unwrap();
     }
-    output.push_str(&format!("-----END {}-----{}", pem.tag, line_ending));
+    write!(output, "-----END {}-----{}", pem.tag, line_ending).unwrap();
 
     output
 }


### PR DESCRIPTION
Shows ~45% performance improvement

Before:

```
pem::encode             time:   [1.0654 µs 1.0674 µs 1.0696 µs]                         
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

pem::encode_many        time:   [2.2387 µs 2.2488 µs 2.2585 µs]                              
```

After:

```
pem::encode             time:   [597.59 ns 603.58 ns 609.70 ns]                         
                        change: [-44.590% -44.219% -43.829%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  2 (2.00%) high mild
  17 (17.00%) high severe

pem::encode_many        time:   [1.2678 µs 1.2723 µs 1.2771 µs]                              
                        change: [-43.377% -43.152% -42.931%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```