### PR TITLE
separate building PRs and testing PRs to different versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,19 @@ jobs:
           components: clippy, rustfmt
       - run: cargo fmt --check
       - run: cargo clippy --all-features -- --deny warnings
-      - run: cargo test --all-features
-      - run: cargo bench --all-features
       # For no_std we use check instead of test because
       # std is required for the test suite to run.
       - run: cargo clippy --no-default-features -- --deny warnings
       - run: cargo check --no-default-features
       # Ensure that serde support works without std
       - run: cargo check --no-default-features --features serde
+  stable:
+    name: stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo test --all-features
+      - run: cargo bench --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //!  assert_eq!(pem.tag(), "RSA PRIVATE KEY");
 //! ```
 //!
-//! # Example: parse a set of PEM-encoded test
+//! # Example: parse a set of PEM-encoded text
 //!
 //! Sometimes, PEM-encoded files contain multiple chunks of PEM-encoded
 //! text. You might see this if you have an x.509 certificate file that


### PR DESCRIPTION
We want to ensure that everything builds back on 1.60 since we are strictly controlling what (limited) dependencies we have. However, our tests have higher dependencies, so just move them to stable.