### PR TITLE
chore: update to base64 0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ std = [
 serde = ["dep:serde"]
 
 [dependencies.base64]
-version = "0.21.0"
+version = "0.22.0"
 default-features = false
 features = ["alloc"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,7 +767,7 @@ RzHX0lkJl9Stshd/7Gbt65/QYq+v+xvAeT0CoyIg
             Err(e @ PemError::InvalidData(_)) => {
                 assert_eq!(
                     &format!("{}", e.source().unwrap()),
-                    "Invalid byte 63, offset 63."
+                    "Invalid symbol 63, offset 63."
                 );
             }
             _ => unreachable!(),


### PR DESCRIPTION
Updates to `base64` 0.22.0.