### PR TITLE
update inline documentation to use latest version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pem = "2"
+//! pem = "3"
 //! ```
 //!
 //! Using the `serde` feature will implement the serde traits for


### PR DESCRIPTION
This is shown on the main page of https://docs.rs/pem/