### PR TITLE
chore: switch serde to serde_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,17 @@ rust-version = "1.60.0"
 default = ["std"]
 std = [
     "base64/std",
-    # enable serde's std feature iff the serde and std features are both activated
-    "serde?/std",
+    # enable serde_core's std feature iff the serde and std features are both activated
+    "serde_core?/std",
 ]
-serde = ["dep:serde"]
+serde = ["dep:serde_core"]
 
 [dependencies.base64]
 version = "0.22.0"
 default-features = false
 features = ["alloc"]
 
-[dependencies.serde]
+[dependencies.serde_core]
 version = "1"
 default-features = false
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,7 @@ pub fn encode_many_config(pems: &[Pem], config: EncodeConfig) -> String {
 mod serde_impl {
     use super::{encode, parse, Pem};
     use core::fmt;
-    use serde::{
+    use serde_core::{
         de::{Error, Visitor},
         Deserialize, Serialize,
     };
@@ -592,7 +592,7 @@ mod serde_impl {
     impl Serialize for Pem {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
-            S: serde::Serializer,
+            S: serde_core::Serializer,
         {
             serializer.serialize_str(&encode(self))
         }
@@ -618,7 +618,7 @@ mod serde_impl {
     impl<'de> Deserialize<'de> for Pem {
         fn deserialize<D>(deserializer: D) -> Result<Pem, D::Error>
         where
-            D: serde::Deserializer<'de>,
+            D: serde_core::Deserializer<'de>,
         {
             deserializer.deserialize_str(PemVisitor)
         }


### PR DESCRIPTION
Switches `serde` crate to `serde_core` to improve users compilation parallelism.