### PR TITLE
docs(parse-many): add warning about invalid data while parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,13 @@ pub fn parse<B: AsRef<[u8]>>(input: B) -> Result<Pem> {
 
 /// Parses a set of PEM-encoded data from a data-type that can be dereferenced as a [u8].
 ///
+/// # NOTE: A fair bit of warning!
+///
+/// Please note that any parts of the input data not representing PEM-encoded data will be ignored.
+/// This also has the effect that parsing input data which doesn't contain any PEM-encoded data at
+/// all will return `Ok([])` instead of an error. Your code should guard against this case with
+/// extra checks if you would expect an error! See examples
+///
 /// # Example: parse a set of PEM-encoded data from a Vec<u8>
 ///
 /// ```rust
@@ -468,6 +475,52 @@ pub fn parse<B: AsRef<[u8]>>(input: B) -> Result<Pem> {
 /// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
 /// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
 /// -----END CERTIFICATE-----
+/// ";
+///  let SAMPLE_STRING: Vec<u8> = SAMPLE.into();
+///
+///  let pems = parse_many(SAMPLE_STRING).unwrap();
+///  assert_eq!(pems.len(), 2);
+///  assert_eq!(pems[0].tag(), "INTERMEDIATE CERT");
+///  assert_eq!(pems[1].tag(), "CERTIFICATE");
+/// ```
+///
+/// # Example: parsing invalid input data without any PEM-encoded data returns empty vec
+///
+/// ```rust
+/// use pem::parse_many;
+///
+/// const SAMPLE: &'static str = "invalid";
+///  let SAMPLE_STRING: Vec<u8> = SAMPLE.into();
+///
+///  let pems = parse_many(SAMPLE_STRING).expect("Does NOT error!");
+///  assert_eq!(pems.len(), 0);
+/// ```
+///
+/// # Example: parse a set of PEM-encoded data from a String with garbage parts
+///
+/// ```rust
+///
+/// use pem::parse_many;
+///
+/// const SAMPLE: &'static str = "invalid data Hello, World! invalid data-----BEGIN INTERMEDIATE CERT-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END INTERMEDIATE CERT-----
+///  This is a garbage section of the input string!
+/// -----BEGIN CERTIFICATE-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END CERTIFICATE-----invalid data Goodbye, World! invalid data
 /// ";
 ///  let SAMPLE_STRING: Vec<u8> = SAMPLE.into();
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,11 @@ impl fmt::Display for Pem {
 
 /// Parses a single PEM-encoded data from a data-type that can be dereferenced as a [u8].
 ///
+/// NOTE: The data doesn't have to be sanitized, meaning random garbage prefixes and suffixes are
+/// just ignored by the parser. The parser will fail if no PEM blob is found in the data. If
+/// multiple PEM blobs are in the input data, the parser will return only data of the first parsed
+/// blob.
+///
 /// # Example: parse PEM-encoded data from a Vec<u8>
 /// ```rust
 ///
@@ -400,6 +405,68 @@ impl fmt::Display for Pem {
 ///
 ///  let pem = parse(SAMPLE_STRING).unwrap();
 ///  assert_eq!(pem.tag(), "RSA PRIVATE KEY");
+/// ```
+///
+/// # Example: parse PEM-encoded data from a String with garbage prefix & suffix data
+/// ```rust
+///
+/// use pem::parse;
+///
+/// const SAMPLE: &'static str = "Hello, World!-----BEGIN RSA PRIVATE KEY-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END RSA PRIVATE KEY-----Goodbye, World!
+/// ";
+/// let SAMPLE_STRING: String = SAMPLE.into();
+///
+///  let pem = parse(SAMPLE_STRING).unwrap();
+///  assert_eq!(pem.tag(), "RSA PRIVATE KEY");
+/// ```
+///
+/// # Example: parse PEM-encoded data with two PEM blobs only parses first
+/// ```rust
+///
+/// use pem::parse;
+///
+/// const SAMPLE: &'static str = "-----BEGIN RSA PRIVATE KEY-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END RSA PRIVATE KEY-----
+/// -----BEGIN CERTIFICATE KEY-----
+/// MIIBPQIBAAJBAOsfi5AGYhdRs/x6q5H7kScxA0Kzzqe6WI6gf6+tc6IvKQJo5rQc
+/// dWWSQ0nRGt2hOPDO+35NKhQEjBQxPh/v7n0CAwEAAQJBAOGaBAyuw0ICyENy5NsO
+/// 2gkT00AWTSzM9Zns0HedY31yEabkuFvrMCHjscEF7u3Y6PB7An3IzooBHchsFDei
+/// AAECIQD/JahddzR5K3A6rzTidmAf1PBtqi7296EnWv8WvpfAAQIhAOvowIXZI4Un
+/// DXjgZ9ekuUjZN+GUQRAVlkEEohGLVy59AiEA90VtqDdQuWWpvJX0cM08V10tLXrT
+/// TTGsEtITid1ogAECIQDAaFl90ZgS5cMrL3wCeatVKzVUmuJmB/VAmlLFFGzK0QIh
+/// ANJGc7AFk4fyFD/OezhwGHbWmo/S+bfeAiIh2Ss2FxKJ
+/// -----END CERTIFICATE KEY-----
+/// ";
+/// let SAMPLE_STRING: String = SAMPLE.into();
+///
+///  let pem = parse(SAMPLE_STRING).unwrap();
+///  assert_eq!(pem.tag(), "RSA PRIVATE KEY");
+/// ```
+///
+/// # Example: parsing invalid input data without any PEM-encoded data fails with an error
+///
+/// ```rust
+/// use pem::parse;
+///
+/// const SAMPLE: &'static str = "invalid";
+///  let SAMPLE_STRING: Vec<u8> = SAMPLE.into();
+///
+///  let error = parse(SAMPLE_STRING).expect_err("DOES error!");
 /// ```
 pub fn parse<B: AsRef<[u8]>>(input: B) -> Result<Pem> {
     parse_captures(input.as_ref())


### PR DESCRIPTION
The crate allows parsing of data that just contains `any` PEM blob data. This means that it will not reject data that has non-whitespace prefixes or suffixes. While this is perfectly fine behavior, the docs tell users nothing at all about this while exposing a falliable `Result<_,_>` interface in both main parsing functions. This seems like a footgun, which is why this PR adds some documentation describing the behavior of the functions.

Moreover, `parse_many` even accepts data containing no PEM blob at all while still returning an `Ok(_)` result while `parse` would reject such inputs with an `Err(_)`. This is also highly unintuitive and is now documented.